### PR TITLE
Fixing random genRandomTest method in TestBerlekampWelchDecode

### DIFF
--- a/src/test/java/at/archistar/crypto/decode/TestBerlekampWelchDecoder.java
+++ b/src/test/java/at/archistar/crypto/decode/TestBerlekampWelchDecoder.java
@@ -77,11 +77,11 @@ public class TestBerlekampWelchDecoder {
 		}
 		
 		int[] idx = generateRandomIntegerArray(f, n);
-		int[] delta = generateRandomIntegerArray(f, 256);
+		int[] delta = generateRandomIntegerArray(f, 255);
 
-		// Adding a number in range [0, 255] to a number will change it for sure. 
+		// Adding a number in range [1, 255] to a number will change it for sure. 
 		for(int i = 0; i < f; i++){
-		  y[idx[i]] = (y[idx[i]] + delta[i]) % 256;
+		  y[idx[i]] = (y[idx[i]] + delta[i] + 1) % 256;
 		}
 	}
 	


### PR DESCRIPTION
...y points can be less than wanted. Fixed this by generating random and distinct integers with a helper method.

Note: code line 47 is a little bit faulty, since there exists no fair distribution (i.e. throwing a 256-sided dice and doing modulo isn't well distributed) . We can do better, but IMO it shouldn't be a problem in this test.
