### PR TITLE
Checkstyle wanted spaces here.

### DIFF
--- a/src/main/java/at/archistar/crypto/mac/PolyHash.java
+++ b/src/main/java/at/archistar/crypto/mac/PolyHash.java
@@ -22,7 +22,7 @@ public class PolyHash implements MacHelper {
     
     private static int[] createIntArrayFromByte(byte[] a) {
         int[] b = new int[a.length];
-        for (int i=0; i < a.length; i++) {
+        for (int i = 0; i < a.length; i++) {
             b[i] = a[i];
         }
         return b;


### PR DESCRIPTION
I'm not sure if it's the older maven version I'm using or some other reason, but the checkstyle plugin considered it a fatal error that this = had no whitespace around it.
