### PR TITLE
More thorough GF256 tests and one resulting fix.

### DIFF
--- a/src/main/java/at/archistar/crypto/math/gf256/GF256.java
+++ b/src/main/java/at/archistar/crypto/math/gf256/GF256.java
@@ -121,6 +121,10 @@ public class GF256 implements GF {
      */
     @Override
     public int pow(int a, int p) {
+        // The use of 512 for LOG[0] and the all-zero last half of ALOG cleverly
+        // avoids testing 0 in mult, but can't survive arbitrary p*...%255 here.
+        if ( 0 == a && 0 != p )
+          return 0;
         return ALOG_TABLE[p*LOG_TABLE[a] % 255];
     }
     

--- a/src/test/java/at/archistar/crypto/math/AlgebraFundamentals.java
+++ b/src/test/java/at/archistar/crypto/math/AlgebraFundamentals.java
@@ -1,0 +1,180 @@
+package at.archistar.crypto.math;
+
+import java.util.Set;
+import java.util.HashSet;
+
+import static org.junit.Assert.*;
+import org.junit.Test;
+
+abstract class BinOp<T> {
+  final Set<T> S;
+  abstract T eval( T a, T b);
+  
+  BinOp( Set<T> S) {
+    this.S = S;
+    System.err.println( "Testing closure under " + getClass().getName());
+    for ( T a : S ) {
+      for ( T b : S ) {
+        assertTrue( "Not closed under operation", S.contains( eval( a, b)));
+        assertTrue( "Not closed under operation", S.contains( eval( b, a)));
+      }
+    }
+  }
+  
+  Set<T> getS() { return S; }
+
+  boolean commutative() {
+    System.err.println( "Testing commutativity of " + getClass().getName());
+    for ( T a : S ) {
+      for ( T b : S ) {
+	if ( !eval(a, b).equals( eval( b, a)) )
+	  return false;
+      }
+    }
+    return true;
+  }
+  
+  boolean associative() {
+    System.err.println( "Testing associativity of " + getClass().getName());
+    for ( T a : S ) {
+      for ( T b : S ) {
+        for ( T c : S ) {
+	  if ( !eval(a, eval(b, c)).equals( eval( eval(a, b), c)) )
+	    return false;
+	}
+      }
+    }
+    return true;
+  }
+  
+  T identity() {
+    System.err.println( "Testing for identity under " + getClass().getName());
+    e: for ( T e : S ) {
+      for ( T a : S ) {
+        if ( !a.equals( eval( a, e)) )
+	  continue e;
+	if ( !a.equals( eval( e, a)) )
+	  continue e;
+      }
+      return e;
+    }
+    return null;
+  }
+  
+  boolean inverses( T e, T except) {
+    System.err.println( "Testing for inverses under " + getClass().getName());
+    Set<T> unpaired = new HashSet<>( S);
+    if ( null != except )
+      unpaired.remove( except);
+    a: for ( T a : S ) {
+      if ( !unpaired.contains( a) )
+        continue;
+      for ( T b : S ) {
+        if ( e.equals( eval( a, b)) && e.equals( eval( b, a)) ) {
+	  unpaired.remove( a);
+	  unpaired.remove( b);
+	  continue a;
+	}
+      }
+    }
+    return unpaired.isEmpty();
+  }
+}
+
+class Group<T> {
+  final Set<T> S;
+  final BinOp<T> op;
+  final T identity;
+  
+  Group( BinOp<T> op) {
+    this.S = op.getS();
+    this.op = op;
+    
+    assertTrue( "operator is not associative", op.associative());
+    identity = op.identity();
+    assertNotNull( "has no identity element", identity);
+    assertTrue( "has elements without inverses", op.inverses( identity, null));
+  }
+  
+  boolean abelian() {
+    return op.commutative();
+  }
+}
+
+class Ring<T> extends Group<T> {
+  final BinOp<T> mulOp;
+  final T unity;
+  
+  Ring( BinOp<T> addOp, BinOp<T> mulOp) {
+    super( addOp);
+    this.mulOp = mulOp;
+    assertSame( "operations defined over different sets", S, mulOp.getS());
+    assertTrue( "not abelian under addition", abelian());
+    assertTrue( "multiply operator is not associative", mulOp.associative());
+    assertTrue( "mul does not distribute over add", distributesOver(mulOp, op));
+    unity = mulOp.identity();
+  }
+  
+  boolean distributesOver( BinOp<T> op1, BinOp<T> op2) {
+    System.err.println( "Testing distributivity for " + getClass().getName());
+    for ( T a : S ) {
+      for ( T b : S ) {
+        for ( T c : S ) {
+	  T bplusc = op2.eval( b, c);
+	  T ab = op1.eval( a, b);
+	  T ac = op1.eval( a, c);
+	  if ( !op1.eval( a, bplusc).equals( op2.eval( ab, ac)) )
+	    return false;
+	  T ba = op1.eval( b, a);
+	  T ca = op1.eval( c, a);
+	  if ( !op1.eval( bplusc, a).equals( op2.eval( ba, ca)) )
+	    return false;
+	}
+      }
+    }
+    return true;
+  }
+  
+  boolean commutative() {
+    return mulOp.commutative();
+  }
+  
+  boolean cancelation() {
+    System.err.println( "Testing cancelation for " + getClass().getName());
+    for ( T a : S ) {
+      if ( identity.equals( a) )
+        continue;
+      for ( T b : S ) {
+        if ( identity.equals( b) )
+	  continue;
+	if ( identity.equals( mulOp.eval( a, b)) )
+	  return false;
+	// will also be checked for (b, a) in due course of loops
+      }
+    }
+    return true;
+  }
+  
+  boolean nonzerosInvertible() {
+    return mulOp.inverses( unity, identity);
+  }
+}
+
+class IntegralDomain<T> extends Ring<T> {
+  IntegralDomain( BinOp<T> addOp, BinOp<T> mulOp) {
+    super( addOp, mulOp);
+    assertTrue( "ring not commutative", commutative());
+    assertNotNull( "ring lacks unity", unity);
+    assertTrue( "ring lacks cancelation property", cancelation());
+  }
+}
+
+class Field<T> extends IntegralDomain<T> {
+  @Override
+  boolean cancelation() { return true; } // implied by stricter test below
+
+  Field( BinOp<T> addOp, BinOp<T> mulOp) {
+    super( addOp, mulOp);
+    assertTrue( "not all nonzeros invertible", nonzerosInvertible());
+  }
+}

--- a/src/test/java/at/archistar/crypto/math/TestBCGF256Algebra.java
+++ b/src/test/java/at/archistar/crypto/math/TestBCGF256Algebra.java
@@ -1,0 +1,69 @@
+package at.archistar.crypto.math;
+
+import org.bouncycastle.pqc.math.linearalgebra.GF2mField;
+
+import java.util.Set;
+import java.util.HashSet;
+import java.util.BitSet;
+
+import static org.junit.Assert.*;
+import org.junit.Test;
+import org.junit.Ignore;
+
+public class TestBCGF256Algebra {
+  private final Field<Integer> gf256Abstract;
+  private static Field<Integer> gf256ACache;
+  private final GF2mField gf256 = new GF2mField( 8, 0x11d);
+  private static final int SIZE = 256;
+  private final int ZERO;
+  private final int UNITY;
+  
+  {
+    if ( null == gf256ACache ) {
+      Set<Integer> S = new HashSet<>( SIZE);
+      for ( int i = 0; i < SIZE; ++ i )
+	S.add( i);
+      BinOp<Integer> addOp = new AddOp( S);
+      BinOp<Integer> mulOp = new MulOp( S);
+      // this constructor will verify all the properties needed for a field
+      gf256ACache = new Field<Integer>( addOp, mulOp);
+    }
+    gf256Abstract = gf256ACache;
+    ZERO = gf256Abstract.identity;
+    UNITY = gf256Abstract.unity;
+  }
+  
+  class AddOp extends BinOp<Integer> {
+    AddOp( Set<Integer> S) { super( S); }
+    Integer eval( Integer a, Integer b) {
+      return gf256.add( a, b);
+    }
+  }
+  
+  class MulOp extends BinOp<Integer> {
+    MulOp( Set<Integer> S) { super( S); }
+    Integer eval( Integer a, Integer b) {
+      return gf256.mult( a, b);
+    }
+  }
+  
+  @Test @Ignore // anything^ZERO === UNITY but BC exp(0,0) returns ZERO
+  public void testExp() {
+    System.err.println( "Testing exp correspondence to mult");
+    BitSet bits = new BitSet( SIZE);
+    for ( int a = 0 ; a < SIZE ; ++ a ) {
+      int prod = UNITY;
+      for ( int p = 0 ; p < SIZE ; ++ p ) {
+        int r = gf256.exp( a, p);
+	if ( r != prod )
+	  fail( String.format( "exp and mult disagree: %d^%d -> %d or %d",
+	        a, p, r, prod));
+	if ( bits.get( r) )
+	  break;
+	bits.set( r);
+	prod = gf256.mult( prod, a);
+      }
+      bits.clear();
+    }
+  }
+}

--- a/src/test/java/at/archistar/crypto/math/TestGF256Algebra.java
+++ b/src/test/java/at/archistar/crypto/math/TestGF256Algebra.java
@@ -1,0 +1,113 @@
+package at.archistar.crypto.math;
+
+import at.archistar.crypto.math.gf256.GF256;
+import org.bouncycastle.pqc.math.linearalgebra.GF2mField;
+
+import java.util.Set;
+import java.util.HashSet;
+import java.util.BitSet;
+
+import static org.junit.Assert.*;
+import org.junit.Ignore;
+import org.junit.Test;
+
+public class TestGF256Algebra {
+  private final Field<Integer> gf256Abstract;
+  private static Field<Integer> gf256ACache;
+  private final GF256 gf256 = new GF256();
+  private final GF2mField ref = new GF2mField( 8, 0x11d);
+  private static final int SIZE = 256;
+  private final int ZERO;
+  private final int UNITY;
+  
+  {
+    if ( null == gf256ACache ) {
+      Set<Integer> S = new HashSet<>( SIZE);
+      for ( int i = 0; i < SIZE; ++ i )
+	S.add( i);
+      BinOp<Integer> addOp = new AddOp( S);
+      BinOp<Integer> mulOp = new MulOp( S);
+      // this constructor will verify all the properties needed for a field
+      gf256ACache = new Field<Integer>( addOp, mulOp);
+    }
+    gf256Abstract = gf256ACache;
+    ZERO = gf256Abstract.identity;
+    UNITY = gf256Abstract.unity;
+  }
+  
+  class AddOp extends BinOp<Integer> {
+    AddOp( Set<Integer> S) { super( S); }
+    Integer eval( Integer a, Integer b) {
+      return gf256.add( a, b);
+    }
+  }
+  
+  class MulOp extends BinOp<Integer> {
+    MulOp( Set<Integer> S) { super( S); }
+    Integer eval( Integer a, Integer b) {
+      return gf256.mult( a, b);
+    }
+  }
+  
+  @Test
+  public void testMultVsBC() {
+    System.err.println( "Testing mult agreement with BouncyCastle");
+    for ( int a = 0 ; a < SIZE ; ++ a ) {
+      for ( int b = 0 ; b < SIZE ; ++ b ) {
+        int r = gf256.mult( a, b);
+	int rref = ref.mult( a, b);
+	if ( r != rref )
+	  fail( String.format( "mult vs. BC disagree: %d*%d -> %d or %d",
+	        a, b, r, rref));
+      }
+    }
+  }
+
+  @Test
+  public void testPow() {
+    System.err.println( "Testing pow correspondence with mult");
+    BitSet bits = new BitSet( SIZE);
+    for ( int a = 0 ; a < SIZE ; ++ a ) {
+      int prod = UNITY;
+      for ( int p = 0 ; p < SIZE ; ++ p ) {
+        int r = gf256.pow( a, p);
+	if ( r != prod )
+	  fail( String.format( "pow and mult disagree: %d^%d -> %d or %d",
+	        a, p, r, prod));
+	if ( bits.get( r) )
+	  break;
+	bits.set( r);
+	prod = gf256.mult( prod, a);
+      }
+      bits.clear();
+    }
+  }
+  
+  @Test
+  public void testInverse() {
+    System.err.println( "Testing inverse correspondence with mult");
+    for ( int a = 0 ; a < SIZE ; ++ a ) {
+      if ( ZERO == a )
+        continue;
+      int inv = gf256.inverse( a);
+      if ( UNITY != gf256.mult( a, inv) || UNITY != gf256.mult( inv, a) )
+        fail( String.format( "inverse fails for %d", a));
+    }
+  }
+  
+  @Test
+  public void testDiv() {
+    System.err.println( "Testing div correspondence with mult");
+    for ( int a = 0 ; a < SIZE ; ++ a ) {
+      for ( int b = 0 ; b < SIZE ; ++ b ) {
+        if ( ZERO == b )
+	  continue;
+	int q = gf256.div( a, b);
+	int p = gf256.mult( q, b);
+	if ( a != p )
+	  fail( String.format( "%d/%d -> %d but %d*%d -> %d",
+	        a, b, q, q, b, p));
+      }
+    }
+  }
+}


### PR DESCRIPTION
I was reading over the hand-cranked GF256 code and I could not trivially convince myself of the LOG_TABLE/ALOG_TABLE indexing, so I decided to add a more thorough test to work straight from algebraic definitions and verify the properties of a finite field (and then test pow, inverse, and div against the tested mult operation).

That did in fact turn up one problem with pow, only for the edge case a=0. mult handles zero factors cleverly by having LOG_TABLE[0] (which isn't truly a log) be greater than any sum of two true logs, and therefore point into a second half of ALOG_TABLE that is all zeros. But that trick doesn't survive in pow, where a log gets multiplied by p and then reduced mod 255 ... it just produces very strange values for 0^p.

I didn't think of any better way to fix pow than by adding a conditional.

Perhaps it doesn't really matter much if pow is broken for a=0, as (at least in ShamirPSS) it would not be expected to be called with a=0 as that would correspond to the secret itself. But it seemed safer to correct it. If that makes it too slow, then maybe it could be left unfixed but with the javadoc changed to define it only for a != 0.

As an aside, when I first noticed it failed the test, I added TestBCGF256Algebra to run the same tests on the BouncyCastle implementation, and that _also_ has a problem at a=0 (but only for p=0; they forgot that anything^0 is unity, even though 0^anythingelse is of course 0).
